### PR TITLE
Fixed cast exception problem with String .endsWith when using SSE for…

### DIFF
--- a/src/ring_sse_middleware/wrapper.clj
+++ b/src/ring_sse_middleware/wrapper.clj
@@ -59,8 +59,8 @@
         (.startsWith x "id:")
         (.startsWith x "retry:"))
     ;; looks like already in SSE format, so return as it is
-    (if (or (.endsWith x \return)
-          (.endsWith x \newline))
+    (if (or (.endsWith x "\r")
+          (.endsWith x "\n"))
       x
       (let [^StringBuilder sb (StringBuilder. x)]
         (.append sb \newline)


### PR DESCRIPTION
…matted string as chunk on java 11

When using a SSE formatted string as message I got the following exception on openjdk 11.

The PR solves that by using strings as parameters.

```
Running webserver at http:/127.0.0.1:3000/
java.lang.ClassCastException: class java.lang.Character cannot be cast to class java.lang.String (java.lang.Character and java.lang.String are in module java.base of loader 'bootstrap')
	at ring_sse_middleware.wrapper$as_sse_event.invokeStatic(wrapper.clj:62)
	at ring_sse_middleware.wrapper$as_sse_event.invoke(wrapper.clj:51)
	at ring_sse_middleware.wrapper$wrap_sse_event$sse_wrapper__13995.doInvoke(wrapper.clj:93)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.core$apply.invoke(core.clj:660)
	at ring_sse_middleware.wrapper$wrap_pst$pst_wrapper__14003.doInvoke(wrapper.clj:117)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at ring_sse_middleware.core$streaming_middleware$streaming_handler__14018$fetch_formatted_chunk__14019.invoke(core.clj:104)
	at ring_sse_middleware.adapter.http_kit$generate_stream$fn__14048$fn__14049.invoke(http_kit.clj:33)
	at ring_sse_middleware.adapter.http_kit$generate_stream$fn__14048.invoke(http_kit.clj:32)
	at clojure.core$binding_conveyor_fn$fn__5739.invoke(core.clj:2030)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)


```